### PR TITLE
Add DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,31 +124,24 @@ defmodule SlickWeb.Backoffice.UserLive.Index do
   def create, do: true
   def edit, do: true
 
-  def index do
-    [
-      id: nil,
-      verified: %{
-        name: "Verified"
-        value: fn user ->
-          # You can customize the render yourself.
-          "Verified is #{user.verified}"
-        end
-      }
-    ]
+  index do
+    field :id
+    field :verified, :boolean
+    field :age, :string, render: &__MODULE__.field/1 # 1-arity only, takes the resource itself
   end
 
-  def form_fields do
-    [
-      verified: %{type: :boolean},
-      usernamer: %{
-        type: :custom,
-        opts: [
-          slot: fn form, field ->
-            Phoenix.HTML.Form.text_input(form, field)
-          end
-        ]
-      }
-    ]
+  form do # default for both
+    field :verified, :boolean
+    field :username, :string
+    field :age, :custom, label: "Age", render: &__MODULE__.field/2 # 2-arity, `form` and `field`.
+  end
+
+  form :edit do # form for :edit action
+    ...
+  end
+
+  form :new do # form for :new action
+    ...
   end
 end
 ```
@@ -221,12 +214,19 @@ end
 
 ## Can I use Backoffice in production?
 
-You sure can, I am using it in production with [Slick Inbox](https://slickinbox.com), but do keep in mind the following:
+You sure can, but I would not really advise it. Although it's in active development now, Backoffice is still very early stage (Backoffice isn't even on Hex yet), so it's subject to a lot of API changes.
 
-- Backoffice was part of a refactoring effort out of Slick Inbox, and my use cases for Slick's admin tool is pretty barebone, so you might find a lot of features missing. Do evaluate it thoroughly before adopting for your own usage.
-- Backoffice is still very early stage, expect breaking changes.
+For what it's worth, I am dogfodding it in production with [Slick Inbox](https://slickinbox.com).
 
-And of course, contributions are very welcomed!
+There are quite a number of issues right now:
+
+- [ ] Editing :map doesn't work
+- [ ] Index & Form fields default might not be the best (form fields right now attempts to show assocs, but you need to explicitly preload it and you can't edit them yet.)
+- [ ] Association support is not great
+- [ ] Tailwind CSS is not being purged now, so the CSS file is about 3MB.
+- [ ] etc...
+
+But, I encourage you to try it out anyway and contribute, and together we can make Backoffice great :)
 
 ## What's next for Backoffice?
 

--- a/lib/backoffice/components/filter_component.ex
+++ b/lib/backoffice/components/filter_component.ex
@@ -93,7 +93,8 @@ defmodule Backoffice.FilterComponent do
 
   defp op(:not), do: "not equal to"
   defp op(:contains), do: "contains"
-  defp op(:order_by), do: "is ordered by"
+  defp op(:desc), do: "descending"
+  defp op(:asc), do: "ascending"
   defp op(:lt), do: "is less than"
   defp op(:lte), do: "is less than or equal to"
   defp op(:gt), do: "is greater than"

--- a/lib/backoffice/dsl.ex
+++ b/lib/backoffice/dsl.ex
@@ -73,9 +73,9 @@ defmodule Backoffice.DSL do
   end
 
   defp validate_value!(env, list) when is_list(list) do
-    if Keyword.get(list, :value) != nil do
+    if Keyword.get(list, :render) != nil do
       raise CompileError,
-        description: "If you provide :value, you must also provide :type.",
+        description: "If you provide :render, you must also provide :type.",
         file: env.file,
         line: env.line
     end

--- a/lib/backoffice/dsl.ex
+++ b/lib/backoffice/dsl.ex
@@ -1,0 +1,42 @@
+defmodule Backoffice.DSL do
+  defmacro index(do: block) do
+    index(__CALLER__, block)
+  end
+
+  def index(_caller, block) do
+    prelude =
+      quote do
+        import Backoffice.DSL
+        unquote(block)
+      end
+
+    postlude =
+      quote unquote: false do
+        fields = @index_fields |> Enum.reverse()
+
+        def __index__(), do: unquote(fields)
+      end
+
+    quote do
+      Module.delete_attribute(__MODULE__, :index_fields)
+      unquote(prelude)
+      unquote(postlude)
+    end
+  end
+
+  defmacro field(name, type \\ :string, opts \\ []) do
+    # TODO: Validate type
+    quote do
+      Backoffice.DSL.__field__(__MODULE__, unquote(name), unquote(type), unquote(opts))
+    end
+  end
+
+  def __field__(mod, name, type, opts) do
+    opts =
+      opts
+      |> Keyword.merge(type: type)
+      |> Enum.into(%{})
+
+    Module.put_attribute(mod, :index_fields, {name, Macro.escape(opts)})
+  end
+end

--- a/lib/backoffice/live/form_component.html.leex
+++ b/lib/backoffice/live/form_component.html.leex
@@ -6,10 +6,9 @@
   phx_change: "validate",
   phx_submit: "save",
   as: "resource" %>
-
   <%= for {field, opts} <- @form_fields do %>
     <div class="mt-6 sm:mt-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-      <%= label f, field, class: "block text-sm font-medium leading-5 text-gray-700" %>
+      <%= label f, field, Backoffice.ResourceView.column_name({field, opts}), class: "block text-sm font-medium leading-5 text-gray-700" %>
       <%= Backoffice.ResourceView.form_field f, field, opts %>
       <%= error_tag f, field %>
     </div>

--- a/lib/backoffice/resolvers/ecto.ex
+++ b/lib/backoffice/resolvers/ecto.ex
@@ -23,6 +23,7 @@ defmodule Backoffice.Resolvers.Ecto do
   end
 
   def save(resolver_opts, :edit, changeset) do
+    # TODO: Check if user has toggled `edit` to be true
     repo = Keyword.fetch!(resolver_opts, :repo)
     repo.update(changeset)
   end

--- a/lib/backoffice/resources.ex
+++ b/lib/backoffice/resources.ex
@@ -10,11 +10,12 @@ defmodule Backoffice.Resources do
     quote do
       use Phoenix.LiveView, unquote(live_opts)
 
-      import Backoffice.DSL, only: [index: 1]
+      import Backoffice.DSL, only: [index: 1, form: 1, form: 2]
 
       @behaviour Backoffice.Resources
 
       Module.register_attribute(__MODULE__, :index_fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :form_fields, accumulate: true)
 
       index do
         schema = Backoffice.Resources.resolve_schema(unquote(resource))
@@ -27,11 +28,19 @@ defmodule Backoffice.Resources do
         end
       end
 
+      form do
+        schema = Backoffice.Resources.resolve_schema(unquote(resource))
+
+        for {field, type} <- schema.__changeset__() do
+          field(field, type)
+        end
+      end
+
       def mount(params, session, socket) do
         socket =
           socket
           |> assign(:fields, __MODULE__.__index__())
-          |> assign(:form_fields, __MODULE__.form_fields())
+          |> assign(:form_fields, __MODULE__.__form__())
           |> assign(:resolver, {unquote(resolver), unquote(resolver_opts)})
           |> assign(:row_actions, __MODULE__.row_actions(socket))
           |> assign(:page_actions, __MODULE__.page_actions(socket))
@@ -94,12 +103,14 @@ defmodule Backoffice.Resources do
 
       defp apply_action(socket, :new, page_opts) do
         socket
+        |> assign(:form_fields, Backoffice.Resources.get_form_fields(__MODULE__, :new))
         |> assign(:resource, %unquote(resource){})
       end
 
       defp apply_action(socket, :edit, page_opts) do
         socket
         |> assign(:page_title, "Edit")
+        |> assign(:form_fields, Backoffice.Resources.get_form_fields(__MODULE__, :edit))
         |> assign(
           :resource,
           unquote(resolver).get(unquote(resource), unquote(resolver_opts), page_opts)
@@ -125,16 +136,6 @@ defmodule Backoffice.Resources do
             page_opts
           )
         )
-      end
-
-      # There's __schema__(:fields) and __changeset__ which are better choices.
-      # TODO: remove call to is_tuple/1 and handle embeds/assocs
-      def form_fields do
-        schema = Backoffice.Resources.resolve_schema(unquote(resource))
-
-        for {k, v} <- schema.__changeset__() do
-          {k, %{type: v}}
-        end
       end
 
       def create, do: false
@@ -170,7 +171,7 @@ defmodule Backoffice.Resources do
 
       defoverridable(
         __index__: 0,
-        form_fields: 0,
+        __form__: 0,
         create: 0,
         edit: 0,
         row_actions: 1,
@@ -223,5 +224,13 @@ defmodule Backoffice.Resources do
     |> List.insert_at(3, "path")
     |> Enum.join("_")
     |> String.to_existing_atom()
+  end
+
+  def get_form_fields(mod, action) do
+    try do
+      mod.__form__(action)
+    rescue
+      _ -> mod.__form__()
+    end
   end
 end

--- a/lib/backoffice/views/resource_view.ex
+++ b/lib/backoffice/views/resource_view.ex
@@ -9,7 +9,7 @@ defmodule Backoffice.ResourceView do
 
   def form_field(form, field, opts) do
     type = Map.fetch!(opts, :type)
-    opts = Map.get(opts, :opts, %{})
+    opts = Map.delete(opts, :type)
 
     do_form_field(form, field, type, Enum.into(opts, []))
   end
@@ -161,7 +161,7 @@ defmodule Backoffice.ResourceView do
 
   # Q: Are there any pitfall to allowing user render fields like this?
   defp do_form_field(form, field, :custom, opts) do
-    slot = Keyword.fetch!(opts, :slot)
+    slot = Keyword.fetch!(opts, :render)
 
     slot.(form, field)
   end
@@ -181,14 +181,20 @@ defmodule Backoffice.ResourceView do
 
   def links do
     layout = Application.get_env(:backoffice, :layout)
-    layout.links()
+
+    case layout do
+      nil -> []
+      _ -> layout.links()
+    end
   end
 
   def logo do
     layout = Application.get_env(:backoffice, :layout)
 
-    layout.logo() ||
-      "https://tailwindui.com/img/logos/workflow-logo-indigo-600-mark-gray-800-text.svg"
+    case layout do
+      nil -> "https://tailwindui.com/img/logos/workflow-logo-indigo-600-mark-gray-800-text.svg"
+      _ -> layout.logo()
+    end
   end
 
   def active_link(path, path) do

--- a/lib/backoffice/views/resource_view.ex
+++ b/lib/backoffice/views/resource_view.ex
@@ -124,13 +124,14 @@ defmodule Backoffice.ResourceView do
     end)
   end
 
+  # BUG: updating map field doesn't work now
   defp do_form_field(form, field, :map, opts) do
     opts =
       Keyword.merge(
         [
           class:
             "#{maybe_disabled(opts)} mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md transition",
-          value: Jason.encode!(input_value(form, field))
+          value: inspect(input_value(form, field))
         ],
         opts
       )
@@ -209,7 +210,22 @@ defmodule Backoffice.ResourceView do
     {:safe, value.(resource) || ""}
   end
 
-  def column_value(resource, {field, _}), do: Map.get(resource, field)
+  def column_value(resource, {field, %{type: :boolean}}) do
+    {:safe,
+     """
+     <div class="flex items-center h-5">
+        <input disabled #{Map.get(resource, field) && "checked"} type="checkbox" class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded">
+      </div>
+     """}
+  end
+
+  def column_value(resource, {field, %{type: :map}}) do
+    Map.get(resource, field) |> Jason.encode!(pretty: true)
+  end
+
+  def column_value(resource, {field, _}) do
+    Map.get(resource, field)
+  end
 
   def action_name(field) when is_atom(field), do: action_name({field, nil})
   def action_name({field, nil}), do: Phoenix.Naming.humanize(field)

--- a/lib/backoffice/views/resource_view.ex
+++ b/lib/backoffice/views/resource_view.ex
@@ -202,27 +202,14 @@ defmodule Backoffice.ResourceView do
      """}
   end
 
-  def column_name(field) when is_atom(field), do: column_name({field, nil})
-  def column_name({field, nil}), do: Phoenix.Naming.humanize(field)
+  def column_name({_field, %{label: label}}), do: label
+  def column_name({field, _}), do: Phoenix.Naming.humanize(field)
 
-  def column_name({field, opts}) when is_map(opts) do
-    case opts[:name] do
-      nil -> column_name(field)
-      name -> name
-    end
+  def column_value(resource, {_field, %{value: value}}) when is_function(value) do
+    {:safe, value.(resource) || ""}
   end
 
-  def column_value(resource, {field, opts}) when is_map(opts) do
-    column_value(resource, {field, opts[:value]})
-  end
-
-  def column_value(resource, {field, nil}), do: Map.get(resource, field)
-
-  def column_value(resource, {_field, func}) when is_function(func) do
-    data = func.(resource) || ""
-
-    {:safe, data}
-  end
+  def column_value(resource, {field, _}), do: Map.get(resource, field)
 
   def action_name(field) when is_atom(field), do: action_name({field, nil})
   def action_name({field, nil}), do: Phoenix.Naming.humanize(field)


### PR DESCRIPTION
This PR adds two DSL macro, `index/0` and `form/0,1` (along with `field`).

Todo:
- [] Type checking, error on compile time if unknown type (?)
- [x] Verify that it works nicely with things like Ecto.Enum (and assocs/embeds)
- [] Possibly implement `belongs_to` to make association explicit?