### PR TITLE
Remove Scrivener dependency

### DIFF
--- a/lib/backoffice/filter.ex
+++ b/lib/backoffice/filter.ex
@@ -20,6 +20,10 @@ defmodule Backoffice.Filter do
     {:skip, :page, value}
   end
 
+  def preprocess({"page_size", value}) do
+    {:skip, :page_num, value}
+  end
+
   def preprocess({field, <<"[gte]", value::binary>>}) do
     {:and, String.to_existing_atom(field), {:gte, String.to_integer(value)}}
   end

--- a/lib/backoffice/page.ex
+++ b/lib/backoffice/page.ex
@@ -1,5 +1,5 @@
 defmodule Backoffice.Page do
-  @type t :: %{
+  @type t :: %__MODULE__{
           entries: [term()],
           page_number: integer(),
           page_size: integer(),

--- a/lib/backoffice/resolvers/ecto.ex
+++ b/lib/backoffice/resolvers/ecto.ex
@@ -36,11 +36,15 @@ defmodule Backoffice.Resolvers.Ecto do
   def load(resource, resolver_opts, page_opts) do
     repo = Keyword.fetch!(resolver_opts, :repo)
     preloads = Keyword.get(resolver_opts, :preload, [])
-    page = Map.get(page_opts, "page")
+
+    paginate_opts = %{
+      page_size: parse(Map.get(page_opts, "page_size", 20)),
+      page_number: parse(Map.get(page_opts, "page", 1))
+    }
 
     resource
     |> preload([q], ^preloads)
-    |> repo.paginate(%{page: page})
+    |> paginate(repo, paginate_opts)
   end
 
   def search(_mod, resource, resolver_opts, page_opts) do
@@ -63,4 +67,105 @@ defmodule Backoffice.Resolvers.Ecto do
     |> preload([q], ^preloads)
     |> repo.get(id)
   end
+
+  # Pagination, code adapted from `Scrivener.Ecto`
+  # This is because we don't want to force users to add Scrivener.Ecto to the rest of the application just for Backoffice.
+  @spec paginate(Ecto.Query.t(), atom(), map()) :: Backoffice.Page.t()
+  defp paginate(query, repo, %{
+         page_size: page_size,
+         page_number: page_number
+       }) do
+    total_entries = total_entries(query, repo)
+    total_pages = total_pages(total_entries, page_size)
+
+    page_number = min(total_pages, page_number)
+
+    %Backoffice.Page{
+      entries: entries(query, repo, page_number, total_pages, page_size),
+      page_number: page_number,
+      page_size: page_size,
+      total_entries: total_entries,
+      total_pages: total_pages
+    }
+  end
+
+  defp entries(_, _, page_number, total_pages, _) when page_number > total_pages, do: []
+
+  defp entries(query, repo, page_number, _, page_size) do
+    offset = page_size * (page_number - 1)
+
+    query
+    |> offset(^offset)
+    |> limit(^page_size)
+    |> all(repo)
+  end
+
+  defp total_entries(query, repo) do
+    total_entries =
+      query
+      |> exclude(:preload)
+      |> exclude(:order_by)
+      |> aggregate()
+      |> one(repo)
+
+    total_entries || 0
+  end
+
+  defp aggregate(%{distinct: %{expr: expr}} = query) when expr == true or is_list(expr) do
+    query
+    |> exclude(:select)
+    |> count()
+  end
+
+  defp aggregate(
+         %{
+           group_bys: [
+             %Ecto.Query.QueryExpr{
+               expr: [
+                 {{:., [], [{:&, [], [source_index]}, field]}, [], []} | _
+               ]
+             }
+             | _
+           ]
+         } = query
+       ) do
+    query
+    |> exclude(:select)
+    |> select([{x, source_index}], struct(x, ^[field]))
+    |> count()
+  end
+
+  defp aggregate(query) do
+    query
+    |> exclude(:select)
+    |> select(count("*"))
+  end
+
+  defp count(query) do
+    query
+    |> subquery
+    |> select(count("*"))
+  end
+
+  defp total_pages(0, _), do: 1
+
+  defp total_pages(total_entries, page_size) do
+    (total_entries / page_size) |> Float.ceil() |> round
+  end
+
+  defp all(query, repo) do
+    repo.all(query)
+  end
+
+  defp one(query, repo) do
+    repo.one(query)
+  end
+
+  defp parse(string) when is_binary(string) do
+    string
+    |> Integer.parse()
+    |> elem(0)
+  end
+
+  defp parse(term), do: term
 end

--- a/lib/backoffice/views/resource_view.ex
+++ b/lib/backoffice/views/resource_view.ex
@@ -263,7 +263,7 @@ defmodule Backoffice.ResourceView do
         <p class="text-sm leading-5 text-gray-700">
           Showing
           <span class="font-medium">
-            <%= page.page_number * page.page_size - page.page_size %>
+            <%= (page.page_number * page.page_size - page.page_size) + 1 %>
           </span>
           to
           <span class="font-medium">


### PR DESCRIPTION
Currently Backoffice assumes your Repo has a `.paginate` function, which
is usually done by `use Scrivener` in your Repo module.

It doesn't really make sense to ask users to include Scrivener just for
Backoffice (and what if they have a separate pagination set-up
already?), so in this commit we remove the assumption and manually
offset our results.