### PR TITLE
Nested links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ defmodule YourAppWeb.Backoffice.Layout do
         """
       },
       %{
+        label: "Nested Links",
+        expanded: true # default to false
+        links: [
+          %{
+            label: "Nested 1",
+            link: "#"
+          },
+          %{
+            label: "Nested 2",
+            link: "#"
+          }
+        ]
+      }
+      %{
         label: "LiveDashboard",
         link: "/admin/dashboard",
         icon: """

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,17 +1,22 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  purge: [
-    '../lib/backoffice/components/*.ex',
-    '../lib/backoffice/widgets/*.ex',
-    '../lib/backoffice/templates/**/*.eex',
-    '../lib/backoffice/templates/**/*.leex',
-    '../lib/backoffice/views/*.ex',
-    '../lib/backoffice/*.ex',
-    '../lib/backoffice/live/*.ex',
-    '../lib/backoffice/live/*.leex',
-    '../lib/backoffice/templates/resource/*.leex'
-  ],
+  purge: {
+    content: [
+      '../lib/backoffice/components/*.ex',
+      '../lib/backoffice/widgets/*.ex',
+      '../lib/backoffice/templates/**/*.eex',
+      '../lib/backoffice/templates/**/*.leex',
+      '../lib/backoffice/views/*.ex',
+      '../lib/backoffice/*.ex',
+      '../lib/backoffice/live/*.ex',
+      '../lib/backoffice/live/*.leex',
+      '../lib/backoffice/templates/resource/*.leex'
+    ],
+    options: {
+      safelist: ['ml-0', 'ml-2', 'ml-4', 'ml-6', 'ml-8'],
+    }
+  },
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {

--- a/lib/backoffice/dsl.ex
+++ b/lib/backoffice/dsl.ex
@@ -130,7 +130,7 @@ defmodule Backoffice.DSL do
     end
   end
 
-  def __belongs_to__(_env, mod, name, schema, opts) do
+  def __belongs_to__(_env, mod, name, _schema, opts) do
     assoc = Module.get_attribute(mod, :resource).__schema__(:association, name)
 
     opts =
@@ -154,7 +154,7 @@ defmodule Backoffice.DSL do
     end
   end
 
-  def __has_one__(_env, mod, name, schema, opts) do
+  def __has_one__(_env, mod, name, _schema, opts) do
     assoc = Module.get_attribute(mod, :resource).__schema__(:association, name)
 
     opts =
@@ -178,7 +178,7 @@ defmodule Backoffice.DSL do
     end
   end
 
-  def __has_many__(_env, mod, name, schema, opts) do
+  def __has_many__(_env, mod, name, _schema, opts) do
     assoc = Module.get_attribute(mod, :resource).__schema__(:association, name)
 
     opts =

--- a/lib/backoffice/templates/layout/backoffice.html.eex
+++ b/lib/backoffice/templates/layout/backoffice.html.eex
@@ -85,12 +85,7 @@
                 <img src="<%= logo() %>" alt="Logo" />
               </div>
               <nav class="mt-5 px-2 space-y-1">
-                <%= for link <- links() do %>
-                  <%= link to: link.link, class: active_link(@conn.request_path, link.link) do %>
-                    <%= render_icon(link.icon) %>
-                    <%= link.label %>
-                  <% end %>
-                <% end %>
+                <%= render_links(@conn, links()) %>
               </nav>
             </div>
             <div class="flex-shrink-0 flex border-t border-gray-200 p-4">
@@ -125,12 +120,7 @@
                 <img src="<%= logo() %>" alt="Logo" />
               </div>
               <nav class="mt-5 flex-1 px-2 bg-white space-y-1">
-                <%= for link <- links() do %>
-                  <%= link to: link.link, class: active_link(@conn.request_path, link.link) do %>
-                    <%= render_icon(link.icon) %>
-                    <%= link.label %>
-                  <% end %>
-                <% end %>
+                <%= render_links(@conn, links()) %>
               </nav>
             </div>
             <div class="flex-shrink-0 flex border-t border-gray-200 p-4">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20277437/114771377-c1e57000-9d6c-11eb-8e3b-d546b7cfb89c.png)

Nice little support for nested links, one thing to improve here is with animations.

I was trying to use one single arrow and then use `transform: rotate(180deg)` but I need to tie it to the `expanded` state, and I think Alpine's x-transition directive only works for inserting/removing from DOM, so that didn't work