### PR TITLE
Reference app.js and app.css in layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,17 @@ defmodule YourAppWeb.Backoffice.UserLive.Single do
 end
 ```
 
-4. Set-up your resource module in the route.
+4. Provide the following plug in your endpoint.ex
+
+```elixir
+plug Plug.Static,
+    at: "/backoffice",
+    from: :backoffice,
+    gzip: false,
+    only: ~w(css js)
+```
+
+5. Set-up your resource module in the route.
 
 ```elixir
 scope "/admin", YourAppWeb, do
@@ -211,7 +221,7 @@ scope "/admin", YourAppWeb, do
 end
 ```
 
-5. You are done!
+6. You are done!
 
 ## Resolvers?
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,31 @@ plug Plug.Static,
     only: ~w(css js)
 ```
 
-5. Set-up your resource module in the route.
+If `/backoffice` conflicts with one of your existing routes, you can customize the static_path in `YourAppWeb.Backoffice.Layout`
+
+```elixir
+# lib/your_app_web/live/backoffice/layout.ex
+  
+  # Add this. Defaults to "/backoffice" if not overriden
+  def static_path(), do: "/whatever_you_want"  
+
+  # ...  the stylesheets, scripts, logo and links function
+end 
+
+# lib/your_app_web/endpoint.ex
+defmodule MyAppWeb.Endpoint do
+
+    # Add this instead
+    plug Plug.Static,
+      at: YourAppWeb.Backoffice.Layout.static_path(),
+      from: :backoffice,
+      gzip: false,
+      only: ~w(css js)
+
+   # ... other plugs
+end 
+
+5. Set-up your resource module in the router.
 
 ```elixir
 scope "/admin", YourAppWeb, do

--- a/lib/backoffice/layout.ex
+++ b/lib/backoffice/layout.ex
@@ -5,4 +5,5 @@ defmodule Backoffice.Layout do
   @callback logo() :: String.t()
   @callback stylesheets() :: [String.t()]
   @callback scripts() :: [String.t()]
+  @callback static_path() :: String.t()
 end

--- a/lib/backoffice/layout_view.ex
+++ b/lib/backoffice/layout_view.ex
@@ -5,17 +5,6 @@ defmodule Backoffice.LayoutView do
     root: "lib/backoffice/templates",
     namespace: Backoffice
 
-  js_path = Path.join(__DIR__, "../../priv/static/js/app.js")
-  css_path = Path.join(__DIR__, "../../priv/static/css/app.css")
-
-  @external_resource js_path
-  @external_resource css_path
-
-  @app_js File.read!(js_path)
-  @app_css File.read!(css_path)
-
-  def render("app.js", _), do: @app_js
-  def render("app.css", _), do: @app_css
 
   def live_socket_path(conn) do
     [Enum.map(conn.script_name, &["/" | &1]) | conn.private.live_socket_path]

--- a/lib/backoffice/layout_view.ex
+++ b/lib/backoffice/layout_view.ex
@@ -93,6 +93,15 @@ defmodule Backoffice.LayoutView do
     end
   end
 
+  def static_path do
+    layout = Application.get_env(:backoffice, :layout)
+
+    case layout && function_exported?(layout, :static_path, 0) do
+      true -> layout.static_path()
+      _ -> "/backoffice"
+    end
+  end
+
   def logo do
     layout = Application.get_env(:backoffice, :layout)
 

--- a/lib/backoffice/templates/layout/backoffice.html.eex
+++ b/lib/backoffice/templates/layout/backoffice.html.eex
@@ -5,16 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-    <style>
-      <%= raw(render("app.css")) %>
-    </style>
+    <link rel="stylesheet" href="/backoffice/css/app.css"/>
     <%= for style <- render_stylesheets() do %>
       <link rel="stylesheet" href="<%= style %>" />
     <% end %>
     <%= csrf_meta_tag() %>
-    <script>
-      <%= raw(render("app.js")) %>;
-    </script>
+    <script src="/backoffice/js/app.js"></script>
     <%= for script <- render_scripts() do %>
       <script type="text/javascript" src="<%= script %>"></script>
     <% end %>

--- a/lib/backoffice/templates/layout/backoffice.html.eex
+++ b/lib/backoffice/templates/layout/backoffice.html.eex
@@ -5,12 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-    <link rel="stylesheet" href="/backoffice/css/app.css"/>
+    <link rel="stylesheet" href=<%= static_path() <> "/css/app.css"%>/>
+
     <%= for style <- render_stylesheets() do %>
       <link rel="stylesheet" href="<%= style %>" />
     <% end %>
     <%= csrf_meta_tag() %>
-    <script src="/backoffice/js/app.js"></script>
+
+    <script src=<%= static_path() <> "/js/app.js" %> ></script>
     <%= for script <- render_scripts() do %>
       <script type="text/javascript" src="<%= script %>"></script>
     <% end %>


### PR DESCRIPTION
- Modify backoffice.html.eex to reference app.css and app.js instead of inlining them in the html
- Update README to provide instructions

For issue #49 